### PR TITLE
Adding logic to find and run failed actions in V2 logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,27 @@ human-readable way with the `printlog` command:
 
     $ bazel-bin/remote_client --grpc_log PATH_TO_LOG printlog
 
+## Getting a list of failed actions
+
+This is available to Remote API V2 functionality, which is present in Bazel 0.17
+and onward.
+
+The remote tool can analyse the grps log and print a list of digests of failed
+actions:
+
+    $ bazel-bin/remote_client --grpc_log PATH_TO_LOG failed_actions
+
+For the purpose of this command, a failed action is any action whose execute
+response returned a non-zero status. This does not include actions whose
+*execution* failed, for example, when remote execution was unavailable or
+returned internal errors.
+
+
 ### Running Actions in Docker
 
 This is available to Remote API V2 functionality, which is present in Bazel 0.17
-and onward:
+and onward.
+
 
 Given an Action in protobuf text format that provides a `container-image` platform, this tool can
 set up its inputs in a local directory and print a Docker command that will run this individual
@@ -126,6 +143,17 @@ For V1 API and earlier, the action protos have not been stored in CAS.
 Instead of using action digest, the above commands can use the parameter
 --textproto to specify a path to a text proto file containing a V1 action.
 This can be copy-pasted from an Execute call in the grpc log.
+
+For V2 API and later, you can skip specifying the action digest if `grpc_log` is
+specified. In this case, the tool will scan the log for failed actions. If a
+single failed action is found, it will use that action's digest. If multiple
+failed actions are found, it will print a list of options.
+
+    $ bazel-bin/remote_client \
+        --remote_cache=localhost:8080 \
+        --grpc_log=/tmp/grpclog
+        run
+
 
 ## Developer Information
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,17 @@ new_http_archive(
     build_file = "BUILD.remoteapis",
 )
 
+# Bazel toolchains
+http_archive(
+  name = "bazel_toolchains",
+  urls = [
+    "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/bc09b995c137df042bb80a395b73d7ce6f26afbe.tar.gz",
+    "https://github.com/bazelbuild/bazel-toolchains/archive/bc09b995c137df042bb80a395b73d7ce6f26afbe.tar.gz",
+  ],
+  strip_prefix = "bazel-toolchains-bc09b995c137df042bb80a395b73d7ce6f26afbe",
+  sha256 = "4329663fe6c523425ad4d3c989a8ac026b04e1acedeceb56aa4b190fa7f3973c",
+)
+
 load("//3rdparty:workspace.bzl", "maven_dependencies", "declare_maven")
 
 maven_dependencies(declare_maven)

--- a/src/main/java/com/google/devtools/build/remote/client/ActionGrouping.java
+++ b/src/main/java/com/google/devtools/build/remote/client/ActionGrouping.java
@@ -1,14 +1,28 @@
 package com.google.devtools.build.remote.client;
 
+import build.bazel.remote.execution.v2.ActionResult;
+import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ExecuteResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.TreeMultiset;
+import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.ExecuteDetails;
 import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.LogEntry;
+import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.RpcCallDetails;
+import com.google.longrunning.Operation;
+import com.google.longrunning.Operation.ResultCase;
+import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import io.grpc.Status.Code;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /** A class to handle GRPc log grouped by actions */
 final class ActionGrouping {
@@ -21,39 +35,164 @@ final class ActionGrouping {
 
   @VisibleForTesting static final String actionString = "Entries for action with hash '%s'\n";
 
-  // Key: actionId; Value: a set of associated log entries.
-  Map<String, Multiset<LogEntry>> actionMap = new HashMap<>();
-  int numSkipped = 0;
+  // A summary of ActionResult for a single action:
+  // This finds and records an ActionResult, regardless of how it was obtained.
+  static class ActionResultSummary {
+    String actionId;
+    ActionResult actionResult;
 
-  public void addLogEntry(LogEntry entry) {
+    Timestamp latestErrorTimestamp = Timestamps.MIN_VALUE;
+    String latestError;
+
+    ActionResultSummary(String actionId) {
+      this.actionId = actionId;
+    }
+
+    ActionResult getActionResult() {
+      return actionResult;
+    }
+
+    private void setResult(ActionResult result) {
+      if (this.actionResult != null) {
+        System.err.println(
+            "Warning: unexpected log format: multiple action results for action " + actionResult);
+      }
+      actionResult = result;
+    }
+
+    private void add(List<Operation> operations) throws IOException {
+      for(Operation o : operations) {
+        StringBuilder error = new StringBuilder();
+        ExecuteResponse response = LogParserUtils.getExecutionResponse(o, ExecuteResponse.class, error);
+        if(response != null && response.hasResult()) {
+          setResult(response.getResult());
+        }
+      }
+    }
+
+    void add(LogEntry entry) throws IOException {
+      if(!entry.hasDetails()) {
+        return;
+      }
+
+      if(entry.getStatus().getCode() != Code.OK.value()) {
+        return;
+      }
+
+      RpcCallDetails details = entry.getDetails();
+
+      if(details.hasExecute()) {
+        add(details.getExecute().getResponsesList());
+      } else if (details.hasWaitExecution()){
+        add(details.getWaitExecution().getResponsesList());
+      } else if (details.hasGetActionResult()) {
+        setResult(details.getGetActionResult().getResponse());
+      }
+    }
+  }
+
+  @VisibleForTesting static class ActionDetails {
+    Multiset<LogEntry> log;
+    Digest digest;
+    ActionResultSummary summary;
+
+    ActionDetails(String actionId) {
+      log = TreeMultiset.create(
+          (a, b) -> {
+            int i = Timestamps.compare(a.getStartTime(), b.getStartTime());
+            if (i != 0) {
+              return i;
+            }
+            // In the improbable case of the same timestamp, ensure the messages do not
+            // override each other.
+            return a.hashCode() - b.hashCode();
+          });
+      summary = new ActionResultSummary(actionId);
+    }
+
+    private Digest extractDigest(LogEntry entry) {
+      if(!entry.hasDetails()) {
+        return null;
+      }
+      RpcCallDetails details = entry.getDetails();
+      if(details.hasExecute()) {
+        if(details.getExecute().hasRequest() && details.getExecute().getRequest().hasActionDigest()) {
+          return details.getExecute().getRequest().getActionDigest();
+        }
+      }
+      if(details.hasGetActionResult()) {
+        if(details.getGetActionResult().hasRequest() && details.getGetActionResult().getRequest().hasActionDigest()) {
+          return details.getGetActionResult().getRequest().getActionDigest();
+        }
+      }
+      return null;
+    }
+
+    Digest getDigest() {
+      return digest;
+    }
+
+    void add(LogEntry entry) throws IOException {
+      log.add(entry);
+
+      Digest d = extractDigest(entry);
+      if(d != null) {
+        if(digest != null && !d.equals(digest)) {
+          System.err.println("Warning: conflicting digests: " + d + " and " + digest);
+        }
+        digest = d;
+      }
+
+      summary.add(entry);
+    }
+
+    // We will consider an action to be failed if we successfully got an action result but the exit
+    // code is non-zero
+    boolean isFailed() {
+      return summary.getActionResult() != null && summary.getActionResult().getExitCode() != 0;
+    }
+
+    Iterable<? extends LogEntry> getSortedElements() {
+      return log;
+    }
+  };
+
+  // Key: actionId; Value: a set of associated log entries.
+  private Map<String, ActionDetails> actionMap = new LinkedHashMap<>();
+
+  // True if found V1 entries in the log.
+  private boolean V1found = false;
+
+  // The number of entries skipped
+  private int numSkipped = 0;
+
+  private boolean isV1Entry(RpcCallDetails details) {
+    return details.hasV1Execute() || details.hasV1FindMissingBlobs() || details.hasV1GetActionResult() || details.hasV1Watch();
+  }
+
+  void addLogEntry(LogEntry entry) throws IOException {
+    if(entry.hasDetails() && isV1Entry(entry.getDetails())) {
+      V1found = true;
+    }
+
     if (!entry.hasMetadata()) {
       numSkipped++;
       return;
     }
     String hash = entry.getMetadata().getActionId();
+
     if (!actionMap.containsKey(hash)) {
-      actionMap.put(
-          hash,
-          TreeMultiset.create(
-              (a, b) -> {
-                int i = Timestamps.compare(a.getStartTime(), b.getStartTime());
-                if (i != 0) {
-                  return i;
-                }
-                // In the improbable case of the same timestamp, ensure the messages do not
-                // override each other.
-                return a.hashCode() - b.hashCode();
-              }));
+      actionMap.put(hash, new ActionDetails(hash));
     }
     actionMap.get(hash).add(entry);
   }
 
-  public void printByAction(PrintWriter out) throws IOException {
+  void printByAction(PrintWriter out) throws IOException {
     for (String hash : actionMap.keySet()) {
       out.println(actionDelimiter);
       out.printf(actionString, hash);
       out.println(actionDelimiter);
-      for (LogEntry entry : actionMap.get(hash)) {
+      for (LogEntry entry : actionMap.get(hash).getSortedElements()) {
         LogParserUtils.printLogEntry(entry, out);
         out.println(entryDelimiter);
       }
@@ -62,5 +201,29 @@ final class ActionGrouping {
       System.err.printf(
           "WARNING: Skipped %d entrie(s) due to absence of request metadata.\n", numSkipped);
     }
+  }
+
+  List<Digest> failedActions() throws IOException {
+    if(V1found) {
+      System.err.println(
+          "This functinality is not supported for V1 API. Please upgrade your Bazel version.");
+      System.exit(1);
+    }
+
+    ArrayList<Digest> result = new ArrayList<>();
+
+    for (String hash : actionMap.keySet()) {
+      ActionDetails a = actionMap.get(hash);
+      if (a.isFailed()) {
+        Digest digest = a.getDigest();
+        if (digest == null) {
+          System.err.println("Error: missing digest for failed action " + hash);
+        } else {
+          result.add(digest);
+        }
+      }
+    }
+
+    return result;
   }
 }

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClient.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClient.java
@@ -34,7 +34,9 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
+import com.google.devtools.build.remote.client.LogParserUtils.ParamException;
 import com.google.devtools.build.remote.client.RemoteClientOptions.CatCommand;
+import com.google.devtools.build.remote.client.RemoteClientOptions.FailedActionsCommand;
 import com.google.devtools.build.remote.client.RemoteClientOptions.GetDirCommand;
 import com.google.devtools.build.remote.client.RemoteClientOptions.GetOutDirCommand;
 import com.google.devtools.build.remote.client.RemoteClientOptions.LsCommand;
@@ -418,6 +420,12 @@ public class RemoteClient {
     parser.printLog(options);
   }
 
+  private static void doFailedActions(String grpcLogFile, FailedActionsCommand options)
+      throws IOException, ParamException {
+    LogParserUtils parser = new LogParserUtils(grpcLogFile);
+    parser.printFailedActions();
+  }
+
   private static void doLs(LsCommand options, RemoteClient client) throws IOException {
     Tree tree = client.getCache().getTree(options.digest);
     client.listTree(Paths.get(""), tree, options.limit);
@@ -493,7 +501,8 @@ public class RemoteClient {
     client.printActionResult(builder.build(), options.limit);
   }
 
-  private static void doRun(RunCommand options, RemoteClient client) throws IOException {
+  private static void doRun(String grpcLogFile, RunCommand options, RemoteClient client)
+      throws IOException, ParamException {
     Path path = options.path != null ? options.path : Files.createTempDir().toPath();
 
     if (options.file != null && options.actionDigest != null) {
@@ -504,7 +513,23 @@ public class RemoteClient {
       client.setupDocker(getActionV1FromFile(options.file), path);
     } else if (options.actionDigest != null) {
       client.setupDocker(client.getAction(options.actionDigest), path);
-    } else {
+    } else if (!grpcLogFile.isEmpty()) {
+      LogParserUtils parser = new LogParserUtils(grpcLogFile);
+      List<Digest> actions = parser.failedActions();
+      if(actions.size() == 0) {
+        System.err.println("No action specified. No failed actions found in GRPC log.");
+        System.exit(1);
+      } else if(actions.size() > 1) {
+        System.err.println("No action specified. Multiple failed actions found in GRPC log. Add one of the following options:");
+        for(Digest d : actions) {
+          System.err.println(" --digest " + d.getHash() + "/" + d.getSizeBytes());
+        }
+        System.exit(1);
+      }
+      Digest action = actions.get(0);
+      client.setupDocker(client.getAction(action), path);
+    }
+    else {
       System.err.println("Specify --file or --action_digest");
       System.exit(1);
     }
@@ -531,6 +556,7 @@ public class RemoteClient {
     GetDirCommand getDirCommand = new GetDirCommand();
     GetOutDirCommand getOutDirCommand = new GetOutDirCommand();
     CatCommand catCommand = new CatCommand();
+    FailedActionsCommand failedActionsCommand = new FailedActionsCommand();
     ShowActionCommand showActionCommand = new ShowActionCommand();
     ShowActionResultCommand showActionResultCommand = new ShowActionResultCommand();
     PrintLogCommand printLogCommand = new PrintLogCommand();
@@ -551,6 +577,7 @@ public class RemoteClient {
             .addCommand("show_action_result", showActionResultCommand, "sar")
             .addCommand("printlog", printLogCommand)
             .addCommand("run", runCommand)
+            .addCommand("failed_actions", failedActionsCommand)
             .build();
 
     try {
@@ -599,7 +626,10 @@ public class RemoteClient {
             showActionResultCommand, makeClientWithOptions(remoteOptions, authAndTlsOptions));
         break;
       case "run":
-        doRun(runCommand, makeClientWithOptions(remoteOptions, authAndTlsOptions));
+        doRun(remoteClientOptions.grpcLog, runCommand, makeClientWithOptions(remoteOptions, authAndTlsOptions));
+        break;
+      case "failed_actions":
+        doFailedActions(remoteClientOptions.grpcLog, failedActionsCommand);
         break;
       default:
         throw new IllegalArgumentException("Unknown command.");

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
@@ -125,6 +125,14 @@ public final class RemoteClientOptions {
   }
 
   @Parameters(
+      commandDescription =
+          "Find and print action ids of failed actions from grpc log.",
+      separators = "=")
+  public static class FailedActionsCommand {
+  }
+
+
+  @Parameters(
       commandDescription = "Parse and display an Action with its corresponding command.",
       separators = "=")
   public static class ShowActionCommand {

--- a/src/test/java/com/google/devtools/build/remote/client/ActionGroupingTest.java
+++ b/src/test/java/com/google/devtools/build/remote/client/ActionGroupingTest.java
@@ -13,14 +13,32 @@
 // limitations under the License.
 package com.google.devtools.build.remote.client;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import build.bazel.remote.execution.v2.ActionResult;
+import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ExecuteRequest;
+import build.bazel.remote.execution.v2.ExecuteResponse;
+import build.bazel.remote.execution.v2.GetActionResultRequest;
 import build.bazel.remote.execution.v2.RequestMetadata;
+import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.ExecuteDetails;
+import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.GetActionResultDetails;
 import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.LogEntry;
+import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.RpcCallDetails;
+import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.WaitExecutionDetails;
+import com.google.devtools.build.remote.client.ActionGrouping.ActionDetails;
+import com.google.devtools.build.remote.client.ActionGrouping.ActionResultSummary;
+import com.google.devtools.build.remote.client.LogParserUtils.ParamException;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
 import com.google.protobuf.util.Timestamps;
+import io.grpc.Status;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Scanner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -102,15 +120,21 @@ public class ActionGroupingTest {
     checkOutput(actionGrouping); // This will ensure there are no delimiters in the output
   }
 
-  private LogEntry getLogEntry(String actionId, String method, int nanos) {
+  private LogEntry getLogEntry(String actionId, String method, int nanos, RpcCallDetails details) {
     RequestMetadata m = RequestMetadata.newBuilder().setActionId(actionId).build();
-    LogEntry result =
+    LogEntry.Builder result =
         LogEntry.newBuilder()
             .setMetadata(m)
             .setMethodName(method)
-            .setStartTime(Timestamps.fromNanos(nanos))
-            .build();
-    return result;
+            .setStartTime(Timestamps.fromNanos(nanos));
+    if(details != null) {
+      result.setDetails(details);
+    }
+    return result.build();
+  }
+
+  private LogEntry getLogEntry(String actionId, String method, int nanos) {
+    return getLogEntry(actionId, method, nanos, null);
   }
 
   private String actionHeader(String actionId) {
@@ -185,5 +209,231 @@ public class ActionGroupingTest {
         ActionGrouping.actionDelimiter,
         "a3_call_1",
         ActionGrouping.entryDelimiter);
+  }
+
+  ActionResult actionResultSuccess = ActionResult.newBuilder().setExitCode(0).build();
+  ActionResult actionResultFail = ActionResult.newBuilder().setExitCode(1).build();
+
+  Digest toDigest(String d) {
+    String[] parts = d.split("/");
+    assert(parts.length == 2);
+    long size = Long.parseLong(parts[1]);
+    return Digest.newBuilder().setHash(parts[0]).setSizeBytes(size).build();
+  }
+
+  private LogEntry makeFailedGetActionResult(int nanos, String digest) {
+    RpcCallDetails.Builder details = RpcCallDetails.newBuilder();
+    details.getGetActionResultBuilder().getRequestBuilder().setActionDigest(toDigest(digest));
+    LogEntry logEntry = getLogEntry(toDigest(digest).getHash(), "getActionResult", nanos, details.build());
+    LogEntry.Builder result = LogEntry.newBuilder(logEntry);
+    result.getStatusBuilder().setCode(Status.NOT_FOUND.getCode().value());
+    return result.build();
+  }
+
+  private RpcCallDetails makeGetActionResult(ActionResult result) {
+    GetActionResultDetails getActionResult = GetActionResultDetails.newBuilder().setResponse(result).build();
+    return RpcCallDetails.newBuilder().setGetActionResult(getActionResult).build();
+  }
+
+  private RpcCallDetails makeGetActionResultWithDigest(ActionResult result, String digest) {
+    GetActionResultRequest request = GetActionResultRequest.newBuilder().setActionDigest(toDigest(digest)).build();
+    GetActionResultDetails getActionResult = GetActionResultDetails.newBuilder().setResponse(result).build();
+    return RpcCallDetails.newBuilder().setGetActionResult(getActionResult).build();
+  }
+
+  private RpcCallDetails makeExecute(ActionResult result) {
+    ExecuteResponse response = ExecuteResponse.newBuilder().setResult(result).build();
+    Operation operation = Operation.newBuilder().setResponse(Any.pack(response)).setDone(true).build();
+    ExecuteDetails execute = ExecuteDetails.newBuilder().addResponses(operation).build();
+    return RpcCallDetails.newBuilder().setExecute(execute).build();
+  }
+
+  private RpcCallDetails makeWatch(ActionResult result) {
+    ExecuteResponse response = ExecuteResponse.newBuilder().setResult(result).build();
+    Operation operation = Operation.newBuilder().setResponse(Any.pack(response)).setDone(true).build();
+    WaitExecutionDetails waitExecution = WaitExecutionDetails.newBuilder().addResponses(operation).build();
+    return RpcCallDetails.newBuilder().setWaitExecution(waitExecution).build();
+  }
+
+  private LogEntry addDigest(LogEntry entry, String digest) {
+    LogEntry.Builder result = LogEntry.newBuilder(entry);
+    assert(entry.hasDetails());
+    if(entry.getDetails().hasExecute()) {
+      result.getDetailsBuilder().getExecuteBuilder().getRequestBuilder().setActionDigest(toDigest(digest));
+    } else if(entry.getDetails().hasGetActionResult()) {
+      result.getDetailsBuilder().getGetActionResultBuilder().getRequestBuilder().setActionDigest(toDigest(digest));
+    } else {
+      assertWithMessage("Can't add digest to an entry that is neither Execute nor GetActionResult").fail();
+    }
+    return result.build();
+  }
+
+  // Test logic to extract action result
+  @Test
+  public void ActionResultForEmpty() {
+    ActionDetails details = new ActionDetails("actionId");
+    // Action with no log entries is not failed but has no actionResult
+    assert(details.summary.getActionResult() == null);
+    assert(!details.isFailed());
+  };
+
+  @Test
+  public void ActionResultFromCachePass() throws IOException {
+    ActionDetails details = new ActionDetails("actionId");
+    // Action with no log entries is not failed but has no actionResult
+    details.add(getLogEntry("actionId", "Execute", 10, makeGetActionResult(actionResultSuccess)));
+    assert(details.summary.getActionResult() != null);
+    assert(!details.isFailed());
+  };
+
+  @Test
+  public void ActionResultFromCacheFail() throws IOException {
+    ActionDetails details = new ActionDetails("actionId");
+    // Action with no log entries is not failed but has no actionResult
+    details.add(getLogEntry("actionId", "Execute", 10, makeGetActionResult(actionResultFail)));
+    assert(details.summary.getActionResult() != null);
+    assert(details.isFailed());
+  };
+
+
+  @Test
+  public void ActionResultFromExecutePass() throws IOException {
+    ActionDetails details = new ActionDetails("actionId");
+    // Action with no log entries is not failed but has no actionResult
+    details.add(getLogEntry("actionId", "Execute", 10, makeExecute(actionResultSuccess)));
+    assert(details.summary.getActionResult() != null);
+    assert(!details.isFailed());
+  };
+
+  @Test
+  public void ActionResultFromExecuteFail() throws IOException {
+    ActionDetails details = new ActionDetails("actionId");
+    // Action with no log entries is not failed but has no actionResult
+    details.add(getLogEntry("actionId", "Execute", 10, makeExecute(actionResultFail)));
+    assert(details.summary.getActionResult() != null);
+    assert(details.isFailed());
+  };
+
+  @Test
+  public void ActionResultFromWatchPass() throws IOException {
+    ActionDetails details = new ActionDetails("actionId");
+    // Action with no log entries is not failed but has no actionResult
+    details.add(getLogEntry("actionId", "Execute", 10, makeWatch(actionResultSuccess)));
+    assert(details.summary.getActionResult() != null);
+    assert(!details.isFailed());
+  };
+
+  @Test
+  public void ActionResultFromWatchFail() throws IOException {
+    ActionDetails details = new ActionDetails("actionId");
+    // Action with no log entries is not failed but has no actionResult
+    details.add(getLogEntry("actionId", "Execute", 10, makeWatch(actionResultFail)));
+    assert(details.summary.getActionResult() != null);
+    assert(details.isFailed());
+  };
+
+  @Test
+  public void FailedActionsEmpty() throws IOException, ParamException {
+    ActionGrouping grouping = new ActionGrouping();
+    List<Digest> result = grouping.failedActions();
+    assert(result.isEmpty());
+  }
+
+  @Test
+  public void FailedActionsAllPass() throws IOException, ParamException {
+    ActionGrouping grouping = new ActionGrouping();
+    grouping.addLogEntry(getLogEntry("actionId", "Execute", 10, makeWatch(actionResultSuccess)));
+    List<Digest> result = grouping.failedActions();
+    assert(result.isEmpty());
+  }
+
+  @Test
+  public void FailedActionsOneFail() throws IOException, ParamException {
+    ActionGrouping grouping = new ActionGrouping();
+    grouping.addLogEntry(addDigest(
+        getLogEntry("12345", "Execute", 10, makeExecute(actionResultSuccess)),
+        "12345/56"));
+    grouping.addLogEntry(addDigest(
+        getLogEntry("987", "Execute", 10, makeExecute(actionResultFail)),
+        "987/22"));
+    grouping.addLogEntry(addDigest(
+        getLogEntry("345", "Execute", 10, makeExecute(actionResultSuccess)),
+        "345/1"));
+    List<Digest> result = grouping.failedActions();
+
+    List<Digest> expected = Arrays.asList(toDigest("987/22"));
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void FailedActionsManyFail() throws IOException, ParamException {
+    ActionGrouping grouping = new ActionGrouping();
+    grouping.addLogEntry(addDigest(
+        getLogEntry("12345", "Execute", 10, makeExecute(actionResultFail)),
+        "12345/56"));
+    grouping.addLogEntry(addDigest(
+        getLogEntry("987", "Execute", 10, makeExecute(actionResultFail)),
+        "987/22"));
+    grouping.addLogEntry(addDigest(
+        getLogEntry("345", "Execute", 10, makeExecute(actionResultFail)),
+        "345/1"));
+    List<Digest> result = grouping.failedActions();
+
+    List<Digest> expected = Arrays.asList(toDigest("12345/56"), toDigest("987/22"), toDigest("345/1"));
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void FailedActionsDifferentResults() throws IOException, ParamException {
+    ActionGrouping grouping = new ActionGrouping();
+    grouping.addLogEntry(addDigest(
+        getLogEntry("12345", "Execute", 10, makeGetActionResult(actionResultFail)),
+        "12345/56"));
+    grouping.addLogEntry(addDigest(
+        getLogEntry("987", "Execute", 10, makeGetActionResult(actionResultSuccess)),
+        "987/22"));
+    grouping.addLogEntry(addDigest(
+        getLogEntry("345", "Execute", 10, makeExecute(actionResultFail)),
+        "345/1"));
+    List<Digest> result = grouping.failedActions();
+
+    List<Digest> expected = Arrays.asList(toDigest("12345/56"), toDigest("345/1"));
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void FailedActionsGetsDigestFromGetActionResult() throws IOException, ParamException {
+    ActionGrouping grouping = new ActionGrouping();
+    grouping.addLogEntry(makeFailedGetActionResult(10, "12345/88"));
+    grouping.addLogEntry(getLogEntry("12345", "Execute", 10, makeWatch(actionResultFail)));
+    List<Digest> result = grouping.failedActions();
+
+    List<Digest> expected = Arrays.asList(toDigest("12345/88"));
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void FailedActionsGetsDigestFromExecute() throws IOException, ParamException {
+    ActionGrouping grouping = new ActionGrouping();
+    grouping.addLogEntry(addDigest(
+        getLogEntry("12345", "Execute", 10, makeExecute(ActionResult.getDefaultInstance())),
+        "12345/1"));
+    grouping.addLogEntry(getLogEntry("12345", "Execute", 10, makeWatch(actionResultFail)));
+    List<Digest> result = grouping.failedActions();
+
+    List<Digest> expected = Arrays.asList(toDigest("12345/1"));
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void FailedActionsDoesntGetDigestFromWrongExecute() throws IOException, ParamException {
+    ActionGrouping grouping = new ActionGrouping();
+    grouping.addLogEntry(addDigest(
+        getLogEntry("wrong_action", "Execute", 10, makeExecute(ActionResult.getDefaultInstance())),
+        "12345/1"));
+    grouping.addLogEntry(getLogEntry("12345", "Execute", 10, makeWatch(actionResultFail)));
+    List<Digest> result = grouping.failedActions();
+
+    assertThat(result).isEmpty();
   }
 }

--- a/src/test/java/com/google/devtools/build/remote/client/BUILD
+++ b/src/test/java/com/google/devtools/build/remote/client/BUILD
@@ -39,6 +39,9 @@ java_test(
         "//3rdparty/jvm/com/google/truth",
         "//src/main/java/com/google/devtools/build/remote/client",
         "//src/main/proto:remote_execution_log_java_proto",
+        "@com_google_protobuf_protobuf_java//jar",
+        "@googleapis//:google_longrunning_operations_java_proto",
+        "@io_grpc_grpc_core//jar",
         "@remoteapis//build/bazel/remote/execution/v2:remote_execution_java_proto",
     ],
 )


### PR DESCRIPTION
- new command "failed_actions" to be used together with grpc_log to find failed actions in the log
- can now use "run" with grpc_log and it will run the failed action from the log (or list failed actions if there are multiple)

Tested: unit tests, manual run for "failed_actions" and "run" with one and 3 failed actions