### PR TITLE
Use Starlark version of 'http_archive' for Bazel >= 0.20 compatibility

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "remote_client")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # Needed for "well-known protos" and @com_google_protobuf//:protoc.
 http_archive(
     name = "com_google_protobuf",
@@ -16,20 +18,20 @@ http_archive(
     urls = ["https://github.com/grpc/grpc-java/archive/d792a72ea15156254e3b3735668e9c4539837fd3.zip"],
 )
 
-new_http_archive(
+http_archive(
     name = "googleapis",
     sha256 = "7b6ea252f0b8fb5cd722f45feb83e115b689909bbb6a393a873b6cbad4ceae1d",
     url = "https://github.com/googleapis/googleapis/archive/143084a2624b6591ee1f9d23e7f5241856642f4d.zip",
     strip_prefix = "googleapis-143084a2624b6591ee1f9d23e7f5241856642f4d",
-    build_file = "BUILD.googleapis",
+    build_file = "@//:BUILD.googleapis",
 )
 
-new_http_archive(
+http_archive(
     name = "remoteapis",
     sha256 = "8ddb673b1346cc7c664bc3ff8b01060b2d2b5eede36d26439e2f1c658d8143f4",
     url = "https://github.com/bazelbuild/remote-apis/archive/998b8625d5947f272142037a1e52a61be33fcefb.zip",
     strip_prefix = "remote-apis-998b8625d5947f272142037a1e52a61be33fcefb",
-    build_file = "BUILD.remoteapis",
+    build_file = "@//:BUILD.remoteapis",
 )
 
 # Bazel toolchains


### PR DESCRIPTION
Hi,

I ran into an issue while trying to build this project using Bazel 0.20.0:

```console
$ bazel build //:remote_client
Starting local Bazel server and connecting to it...
INFO: Invocation ID: d32c4b6a-9707-4801-8bea-4a1c8691ad93
ERROR: Analysis of target '//:remote_client' failed; build aborted: no such package '@googleapis//': The native new_http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
INFO: Elapsed time: 6.744s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (8 packages loaded, 23 targets configured)
    Fetching @googleapis; fetching
```

It appears that the native 'http_archive' functions have been deprecated as of Bazel 0.20. This patch imports the replacements from the Starlark extensions. See: https://github.com/bazelbuild/bazel/issues/6570 for reference.

Making these changes allowed the build to complete.

Thanks!
-S