### PR TITLE
Add command to upload files to CAS

### DIFF
--- a/src/main/java/com/google/devtools/build/remote/client/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/remote/client/AbstractRemoteActionCache.java
@@ -22,6 +22,7 @@ import build.bazel.remote.execution.v2.OutputDirectory;
 import build.bazel.remote.execution.v2.Tree;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -225,4 +226,10 @@ public abstract class AbstractRemoteActionCache {
    * @throws CacheNotFoundException in case of a cache miss.
    */
   public abstract void downloadBlob(Digest digest, OutputStream dest) throws IOException;
+
+  /**
+   * Uploads a single blob with the specified {@link Digest} from the {@link InputStream}
+   * into the CAS.
+   */
+  public abstract void uploadBlob(Digest digest, InputStream source) throws IOException;
 }

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
@@ -210,6 +210,26 @@ public final class RemoteClientOptions {
     public Path path = null;
   }
 
+  @Parameters(
+      commandDescription = "Copies a file to the CAS.",
+      separators = "=")
+  public static class CpCommand {
+    @Parameter(
+        names = {"--digest", "-d"},
+        required = true,
+        converter = DigestConverter.class,
+        description = "The digest in the format hex_hash/size_bytes of the blob to copy.")
+    // TODO(yannic): Infer digest from file.
+    public Digest digest = null;
+
+    @Parameter(
+        names = {"--file", "-o"},
+        required = true,
+        converter = FileConverter.class,
+        description = "Specifies a file to upload.")
+    public File file = null;
+  }
+
   /** Converter for hex_hash/size_bytes string to a Digest object. */
   public static class DigestConverter implements IStringConverter<Digest> {
     @Override


### PR DESCRIPTION
This change adds a new command, `cp`, to upload files to the CAS.
For now, users will have to manually specify the digest of the file
on the command-line. We may want to compute this automatically before
starting to upload the file.