### PR TITLE
Ensure load balancer policies are available at runtime.

### DIFF
--- a/src/main/java/com/google/devtools/build/remote/client/BUILD
+++ b/src/main/java/com/google/devtools/build/remote/client/BUILD
@@ -28,6 +28,7 @@ java_library(
         "@io_grpc_grpc_java//auth",
         "@io_grpc_grpc_java//context",
         "@io_grpc_grpc_java//core",
+        "@io_grpc_grpc_java//core:util",
         "@io_grpc_grpc_java//netty",
         "@io_grpc_grpc_java//protobuf",
         "@io_grpc_grpc_java//stub",


### PR DESCRIPTION
Without the dep on @io_grpc_grpc_java//core:util, running remote_client
results in this error:

java.lang.IllegalStateException: Could not find policy 'round_robin'. Make sure its implementation is either registered to LoadBalancerRegistry or included in META-INF/services/io.grpc.LoadBalancerProvider from your jar files.
	at io.grpc.internal.AutoConfiguredLoadBalancerFactory$AutoConfiguredLoadBalancer.<init>(AutoConfiguredLoadBalancerFactory.java:92)
	at io.grpc.internal.AutoConfiguredLoadBalancerFactory.newLoadBalancer(AutoConfiguredLoadBalancerFactory.java:63)
	at io.grpc.internal.ManagedChannelImpl.exitIdleMode(ManagedChannelImpl.java:409)
	at io.grpc.internal.ManagedChannelImpl$RealChannel$2.run(ManagedChannelImpl.java:984)
	at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:95)
	at io.grpc.SynchronizationContext.execute(SynchronizationContext.java:127)
	at io.grpc.internal.ManagedChannelImpl$RealChannel.newCall(ManagedChannelImpl.java:981)
	at io.grpc.internal.ManagedChannelImpl.newCall(ManagedChannelImpl.java:923)
	at io.grpc.internal.ForwardingManagedChannel.newCall(ForwardingManagedChannel.java:63)
	at io.grpc.stub.MetadataUtils$HeaderAttachingClientInterceptor.interceptCall(MetadataUtils.java:81)
	at io.grpc.ClientInterceptors$InterceptorChannel.newCall(ClientInterceptors.java:156)
	at io.grpc.stub.ClientCalls.blockingServerStreamingCall(ClientCalls.java:200)
	at com.google.bytestream.ByteStreamGrpc$ByteStreamBlockingStub.read(ByteStreamGrpc.java:264)
	at com.google.devtools.build.remote.client.GrpcRemoteCache.readBlob(GrpcRemoteCache.java:149)
	at com.google.devtools.build.remote.client.GrpcRemoteCache.downloadBlob(GrpcRemoteCache.java:129)
	at com.google.devtools.build.remote.client.RemoteClient.getAction(RemoteClient.java:226)
	at com.google.devtools.build.remote.client.RemoteClient.printAction(RemoteClient.java:255)
	at com.google.devtools.build.remote.client.RemoteClient.doShowAction(RemoteClient.java:490)
	at com.google.devtools.build.remote.client.RemoteClient.selectAndPerformCommand(RemoteClient.java:623)
	at com.google.devtools.build.remote.client.RemoteClient.main(RemoteClient.java:541)