### PR TITLE
Filter guava from grpc's maven package list

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,6 +64,9 @@ load(
     "grpc_java_repositories",
 )
 
+# filter grpc dependencies to specify our own guava version
+GUAVA_PACKAGE_PREFIX = "com.google.guava:guava:"
+
 maven_install(
     artifacts = [
         "com.beust:jcommander:1.72",
@@ -71,7 +74,7 @@ maven_install(
         "com.google.http-client:google-http-client:1.23.0",
         "com.google.jimfs:jimfs:1.1",
         "com.googlecode.json-simple:json-simple:1.1.1",
-    ] + IO_GRPC_GRPC_JAVA_ARTIFACTS,
+    ] + [artifact for artifact in IO_GRPC_GRPC_JAVA_ARTIFACTS if not artifact.startswith(GUAVA_PACKAGE_PREFIX)],
     repositories = [
         "https://repo.maven.apache.org/maven2",
     ],


### PR DESCRIPTION
tools_remote depends explicitly on the -jre version variant of guava. Filter any other versions (it presents a -android one currently) from the list of maven dependencies when calling maven_install

This removes a conflict presented during the build between the two versions on repository evaluation.